### PR TITLE
Rename editor test assembly to something unique

### DIFF
--- a/Tests/Editor/Tests.asmdef
+++ b/Tests/Editor/Tests.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests",
+    "name": "UniGit.Editor.Tests",
     "references": [
         "UniGit",
         "UnityEngine.TestRunner",


### PR DESCRIPTION
I ran into a case where another package had the same name as the tests asmdef, so I believe changing the assembly name to something unique to this project (similar to some standard packages like [ProBuilder](https://github.com/Unity-Technologies/com.unity.probuilder/blob/master/Tests/Editor/Unity.ProBuilder.Editor.Tests.asmdef)) would be good.